### PR TITLE
Explicitly use bash

### DIFF
--- a/scripts/script-post.sh
+++ b/scripts/script-post.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 api_key='<PUT_YOUR_API_KEY_HERE>'
 domainID='<PUT_YOUR_DOMAIN_ID_HERE>'
 

--- a/scripts/script-pre.sh
+++ b/scripts/script-pre.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 api_key='<PUT_YOUR_API_KEY_HERE>'
 domainID='<PUT_YOUR_DOMAIN_ID_HERE>'
 


### PR DESCRIPTION
If the hook scripts are executed in an environment where `/bin/sh` is not linked to `bash` the script will fail because of the used IF syntax